### PR TITLE
removing duplicate entry for yarn.nodemanager.bind-host

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -52,7 +52,6 @@ if [ "$MULTIHOMED_NETWORK" = "1" ]; then
     # YARN
     addProperty /etc/hadoop/yarn-site.xml yarn.resourcemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
-    addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.timeline-service.bind-host 0.0.0.0
 
     # MAPRED


### PR DESCRIPTION
yarn.nodemanager.bind-host  is set twice in the entypoint file.