### PR TITLE
Remove lost+found dir

### DIFF
--- a/namenode/run.sh
+++ b/namenode/run.sh
@@ -11,6 +11,9 @@ if [ -z "$CLUSTER_NAME" ]; then
   exit 2
 fi
 
+echo "remove lost+found from $namedir"
+rm -r $namedir/lost+found
+
 if [ "`ls -A $namedir`" == "" ]; then
   echo "Formatting namenode name directory: $namedir"
   $HADOOP_HOME/bin/hdfs --config $HADOOP_CONF_DIR namenode -format $CLUSTER_NAME


### PR DESCRIPTION
While using the namenode with Kubernetes statefulset, due to the fact that the Volume created is not totally empty, init fails. 
To address this issue we need to remove the lost+found directory available by default while volumes are created in Kubernetes