### PR TITLE
removing hardcoded -site extension

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -27,7 +27,7 @@ function configure() {
         var="${envPrefix}_${c}"
         value=${!var}
         echo " - Setting $name=$value"
-        addProperty /etc/hadoop/$module-site.xml $name "$value"
+        addProperty $path $name "$value"
     done
 }
 


### PR DESCRIPTION
As we are already passing the path information to the configure() function, there is no need to regenerate the file name using static -site extension. By doing so, This function can be used for configuration files that do not end with site.xml such as capacity-scheduler.xml