### PR TITLE
added install libsnappy-dev on base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
       curl \
       netcat \
       gnupg \
+      libsnappy-dev \
     && rm -rf /var/lib/apt/lists/*
       
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/


### PR DESCRIPTION
Base image doesn't include native snappy library 
hadoop checknative -a 
returns false for snappy support
