### PR TITLE
Makefile build: all Docker builds to be based on newly built hadoop-base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 DOCKER_NETWORK = docker-hadoop_default
 ENV_FILE = hadoop.env
 current_branch := $(shell git rev-parse --abbrev-ref HEAD)
+base_version := --build-arg HADOOP_BASE_VERSION=$(current_branch)
 build:
 	docker build -t bde2020/hadoop-base:$(current_branch) ./base
-	docker build -t bde2020/hadoop-namenode:$(current_branch) ./namenode
-	docker build -t bde2020/hadoop-datanode:$(current_branch) ./datanode
-	docker build -t bde2020/hadoop-resourcemanager:$(current_branch) ./resourcemanager
-	docker build -t bde2020/hadoop-nodemanager:$(current_branch) ./nodemanager
-	docker build -t bde2020/hadoop-historyserver:$(current_branch) ./historyserver
-	docker build -t bde2020/hadoop-submit:$(current_branch) ./submit
+	docker build -t bde2020/hadoop-namenode:$(current_branch) $(base_version) ./namenode
+	docker build -t bde2020/hadoop-datanode:$(current_branch) $(base_version) ./datanode
+	docker build -t bde2020/hadoop-resourcemanager:$(current_branch) $(base_version) ./resourcemanager
+	docker build -t bde2020/hadoop-nodemanager:$(current_branch) $(base_version) ./nodemanager
+	docker build -t bde2020/hadoop-historyserver:$(current_branch) $(base_version) ./historyserver
+	docker build -t bde2020/hadoop-submit:$(current_branch) $(base_version) ./submit
 
 wordcount:
 	docker build -t hadoop-wordcount ./submit

--- a/datanode/Dockerfile
+++ b/datanode/Dockerfile
@@ -1,4 +1,5 @@
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+ARG HADOOP_BASE_VERSION=2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-base:$HADOOP_BASE_VERSION
 
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 

--- a/historyserver/Dockerfile
+++ b/historyserver/Dockerfile
@@ -1,4 +1,5 @@
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+ARG HADOOP_BASE_VERSION=2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-base:$HADOOP_BASE_VERSION
 
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 

--- a/namenode/Dockerfile
+++ b/namenode/Dockerfile
@@ -1,4 +1,5 @@
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+ARG HADOOP_BASE_VERSION=2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-base:$HADOOP_BASE_VERSION
 
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 

--- a/nodemanager/Dockerfile
+++ b/nodemanager/Dockerfile
@@ -1,4 +1,5 @@
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+ARG HADOOP_BASE_VERSION=2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-base:$HADOOP_BASE_VERSION
 
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 

--- a/resourcemanager/Dockerfile
+++ b/resourcemanager/Dockerfile
@@ -1,4 +1,5 @@
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+ARG HADOOP_BASE_VERSION=2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-base:$HADOOP_BASE_VERSION
 
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 

--- a/submit/Dockerfile
+++ b/submit/Dockerfile
@@ -1,4 +1,5 @@
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+ARG HADOOP_BASE_VERSION=2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-base:$HADOOP_BASE_VERSION
 
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 


### PR DESCRIPTION
The "build" target in the Makefile uses the current git branch name as version tag for all newly built Docker images. However, the images of Hadoop components (namenode, etc.) are not based on the newly built "hadoop-base" image. Instead, the version of the hadoop-base image is hardwired in the Dockerfiles off the components. The Makefile should pass the tag/version of "hadoop-base" image forward to Docker builds of components, so that all newly built component images are based on the same "hadoop-base" image.