### PR TITLE
Docker-compose: network name and port fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Version 2.0.0 introduces uses wait_for_it script for the cluster startup
 # Hadoop Docker
 
 ## Supported Hadoop Versions
-See repository branches for supported hadoop versions
+See repository branches for supported Hadoop versions
 
 ## Quick Start
 
@@ -26,15 +26,16 @@ Or deploy in swarm:
 docker stack deploy -c docker-compose-v3.yml hadoop
 ```
 
-`docker-compose` creates a docker network that can be found by running `docker network list`, e.g. `dockerhadoop_default`.
+`docker-compose` creates a docker network that can be found by running `docker network list`, e.g. `docker-hadoop_default`.
 
-Run `docker network inspect` on the network (e.g. `dockerhadoop_default`) to find the IP the hadoop interfaces are published on. Access these interfaces with the following URLs:
+Run `docker network inspect` on the network (e.g. `docker-hadoop_default`) to find the IP the Hadoop interfaces are published on. Access these interfaces with the following URLs:
 
 * Namenode: http://<dockerhadoop_IP_address>:9870/dfshealth.html#tab-overview
 * History server: http://<dockerhadoop_IP_address>:8188/applicationhistory
-* Datanode: http://<dockerhadoop_IP_address>:9864/
-* Nodemanager: http://<dockerhadoop_IP_address>:8042/node
 * Resource manager: http://<dockerhadoop_IP_address>:8088/
+
+All other Hadoop communication ports are not exposed and only accessible from inside the Docker network using service name and port, eg. `http://namenode:9000/`.
+
 
 ## Configure Environment Variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     restart: always
     ports:
       - 9870:9870
-      - 9000:9000
     volumes:
       - hadoop_namenode:/hadoop/dfs/name
     environment:
@@ -30,6 +29,8 @@ services:
     image: bde2020/hadoop-resourcemanager:2.0.0-hadoop3.2.1-java8
     container_name: resourcemanager
     restart: always
+    ports:
+      - 8088:8088
     environment:
       SERVICE_PRECONDITION: "namenode:9000 namenode:9870 datanode:9864"
     env_file:
@@ -48,6 +49,8 @@ services:
     image: bde2020/hadoop-historyserver:2.0.0-hadoop3.2.1-java8
     container_name: historyserver
     restart: always
+    ports:
+      - 8188:8188
     environment:
       SERVICE_PRECONDITION: "namenode:9000 namenode:9870 datanode:9864 resourcemanager:8088"
     volumes:


### PR DESCRIPTION
- docker-compose.yml: expose only UI ports (HDFS namenode, YARN resource manager and history server). Internal Hadoop communication ports should be reachable only from inside the cluster.
  - add missing UI ports - resource manager and history server (includes #90)
  - remove internal ports
- README.md: fix Docker network name - should be the same as defined by DOCKER_NETWORK in the Makefile (obsoletes #57)