### PR TITLE
Publish datanode http and data transfer ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     image: bde2020/hadoop-datanode:2.0.0-hadoop3.2.1-java8
     container_name: datanode
     restart: always
+    ports:
+      - 9864:9864
+      - 9866:9866
     volumes:
       - hadoop_datanode:/hadoop/dfs/data
     environment:


### PR DESCRIPTION
The following ports should be published from the datanode container so clients outside of Docker can directly communicate with the HDFS data node ([source](https://hadoop.apache.org/docs/r3.0.0/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)):
| name | value | description |
| ----------- | ----------- | ----------- |
| dfs.datanode.address       | 0.0.0.0:9866       |  The datanode server address and port for data transfer. |
| dfs.datanode.http.address   | 0.0.0.0:9864        | The datanode http server address and port. |


